### PR TITLE
Make struct attribute member accessible from Cython extension type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# specific temporary Cython files
+cmesh.c
+
 # Compiled Object files
 *.slo
 *.lo

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# cmesh
+
+## Installation
+
+The usual works:
+
+    $ python setup.py install
+
+or
+
+    python setup.py install --user
+
+if you don't want to mess around with your system Python. Alternately, if you
+want to play around in the directory, you can do
+
+    python setup.py build_ext --inplace
+
+and all of the Python / Cython modules will be built in-place.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+import numpy
+
+from distutils.core import setup
+from distutils.extension import Extension
+from Cython.Distutils import build_ext
+
+ext_modules = [
+    Extension('cmesh',
+              sources=['cmesh.pyx', 'mesh.c'],
+              include_dirs = [numpy.get_include()],
+              extra_compile_args = ['-Wno-unused-function',
+                                    '-Wno-#warnings'])
+    ]
+
+setup(
+    name = 'cmesh',
+    ext_modules = ext_modules,
+    cmdclass = {'build_ext': build_ext},
+    )


### PR DESCRIPTION
A basic example of reading data from a struct (pointer) which is an attribute of a Cython extension type (class). Here's the meat:

```python
@property
    def x(self):
        cdef int n = self.m.nn
        cdef double[:] x = <double[:n]>self.m.x
        return numpy.array(x, dtype=numpy.double)
```